### PR TITLE
Makefile: Add build and run targets

### DIFF
--- a/makefile
+++ b/makefile
@@ -92,12 +92,10 @@ help: ## Makefile help
 	@echo "Available Commands:"
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
-run: ## Run the project
+run: build ## Run the project
 	./$(PATH_BIN)$(BIN_TARGET).$(TARGET_EXTENSION)
 
-
 build: $(PATH_BIN)$(BIN_TARGET).$(TARGET_EXTENSION) $(PATH_BIN) ## Build the project
-
 	
 ## Link compiled files
 $(PATH_BIN)$(BIN_TARGET).$(TARGET_EXTENSION): $(SRC_FILES_OUT)

--- a/makefile
+++ b/makefile
@@ -97,11 +97,10 @@ run: ## Run the project
 
 
 build: $(PATH_BIN)$(BIN_TARGET).$(TARGET_EXTENSION) $(PATH_BIN) ## Build the project
-	@echo "Building..."
+
 	
 ## Link compiled files
 $(PATH_BIN)$(BIN_TARGET).$(TARGET_EXTENSION): $(SRC_FILES_OUT)
-	@echo "Linking to file $@ from files: $<"
 	$(LINK) -o $@ $^
 
 ## Compile c files
@@ -109,7 +108,6 @@ $(PATH_BIN)%.o: $(PATHS)%.c
 	## Make sure directory exists
 	@mkdir -p $(dir $@)
 
-	@echo "Compiling file: $<"
 	$(COMPILE) $(CFLAGS) $< -o $@
 
 


### PR DESCRIPTION
A couple improvements to the makefile:

- Explicitly set shell as bash (throws errors on WSL2)
- Add `build` and `run` targets to be able to compile and run the project on its own.